### PR TITLE
Migration from 4.7.x to 4.8.x

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The following is a working sample that shows how to use Botz classes in a plugin
     <licenseType>Apache 2.0</licenseType>
     <date>2024-06-27</date>
     <minServerVersion>4.8.0</minServerVersion>
-    <minJavaVersion>1.8</minJavaVersion>
 </plugin>
 ```
 
@@ -79,8 +78,8 @@ The following is a working sample that shows how to use Botz classes in a plugin
     <description>Echo bot for Openfire</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openfire.version>4.8.0</openfire.version>
     </properties>
@@ -132,8 +131,8 @@ The following is a working sample that shows how to use Botz classes in a plugin
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>9</source>
-                    <target>9</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To use the library in an Openfire plugin, it needs to be defined as a dependency
     <dependency>
         <groupId>org.igniterealtime.openfire.botz</groupId>
         <artifactId>botz</artifactId>
-        <version>1.1.0</version>
+        <version>1.3.0</version>
     </dependency>
 </dependencies>
 

--- a/README.md
+++ b/README.md
@@ -45,27 +45,179 @@ Botz classes may be used in situations where an internal user bot is needed. Bot
 - Change **BotPacketReceiver** on the fly, thus switch behaviors and create multiple personalities of a bot.
 
 ## Using Botz in A Plugin
-The following is the code snippet that shows a way to use Botz classes in a plugin. The sample plugin is a parrot bot service that simply echoes *<message/>* packets back to the sender.
+The following is a working sample that shows how to use Botz classes in a plugin. The sample plugin is a parrot bot service that simply echoes *<message/>* packets back to the sender.
 
+`plugin.xml`
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<plugin>
+    <author>John Doe</author>
+    <class>org.example.ParrotBot</class>
+    <name>${project.name}</name>
+    <description>${project.description}</description>
+    <version>${project.version}</version>
+    <licenseType>Apache 2.0</licenseType>
+    <date>2024-06-27</date>
+    <minServerVersion>4.8.0</minServerVersion>
+    <minJavaVersion>1.8</minJavaVersion>
+</plugin>
+```
+
+`pom.xml`
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>ParrotBot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>ParrotBot</name>
+    <description>Echo bot for Openfire</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <openfire.version>4.8.0</openfire.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.igniterealtime.openfire.plugins</groupId>
+                        <artifactId>openfire-plugin-assembly-descriptor</artifactId>
+                        <version>${openfire.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <finalName>${project.artifactId}</finalName>
+                            <attach>false</attach>
+                            <descriptorRefs>
+                                <descriptorRef>openfire-plugin-assembly</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.0.0</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.igniterealtime.openfire</groupId>
+            <artifactId>xmppserver</artifactId>
+            <version>${openfire.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    
+        <dependency>
+            <groupId>org.igniterealtime.openfire.botz</groupId>
+            <artifactId>botz</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+    </dependencies>
+    <repositories>
+        <repository>
+            <id>mvnrepository</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+            <id>sonatype</id>
+            <name>Sonatype Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases/</url>
+        </repository>
+        <repository>
+            <id>igniterealtime</id>
+            <name>Ignite Realtime Repository</name>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <!-- Typically used to retrieve Maven plugins that are used by this
+        project.
+             This apparently is also used to obtain the dependencies _used by_ these
+             plugins (such as the openfire-plugin-assembly-descriptor, needed to
+             package the project as an Openfire plugin!) -->
+        <pluginRepository>
+            <id>igniterealtime</id>
+            <name>Ignite Realtime Repository</name>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>mvnrepository</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo1.maven.org/maven2/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>
+```
+`src/main/java/org/example/ParrotBot.java`
 ```java
+package org.example;
+
 import org.igniterealtime.openfire.botz.BotzConnection;
-import org.igniterealtime.openfire.botz.BotzPacketReceiver; 
+import org.igniterealtime.openfire.botz.BotzPacketReceiver;
+import org.jivesoftware.openfire.container.Plugin;
+import org.jivesoftware.openfire.container.PluginManager;
+
+import org.xmpp.packet.Packet;
+import org.xmpp.packet.Presence;
+import org.xmpp.packet.Message;
+import java.io.File;
 
 public class ParrotBot implements Plugin
 {
     @Override
     public void destroyPlugin() {}
-    
+
     @Override
-    public void initializePlugin(PluginManager manager, File pluginDirectory) 
+    public void initializePlugin(PluginManager manager, File pluginDirectory)
     {
         BotzPacketReceiver packetReceiver = new BotzPacketReceiver() {
             BotzConnection bot;
-            
+
             public void initialize(BotzConnection bot) {
                 this.bot = bot;
             }
-            
+
             public void processIncoming(Packet packet) {
                 if (packet instanceof Message) {
                     // Echo back to sender
@@ -74,10 +226,10 @@ public class ParrotBot implements Plugin
                 }
             }
             public void processIncomingRaw(String rawText) { };
-            
+
             public void terminate() { };
-        };  
-        
+        };
+
         BotzConnection bot = new BotzConnection(packetReceiver);
         try {
             // Create user and login

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.igniterealtime.openfire.botz</groupId>
     <artifactId>botz</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
 
     <name>Botz</name>
     <description>The Botz library adds to the already rich and extensible Openfire with the ability to create internal user bots. With the Botz library, programmers may choose to develop a user bot to run as a service bearing myservice@example.com as its JID. To Openfire, the user bot is just like other (human) users.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.igniterealtime.openfire.botz</groupId>
     <artifactId>botz</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <name>Botz</name>
     <description>The Botz library adds to the already rich and extensible Openfire with the ability to create internal user bots. With the Botz library, programmers may choose to develop a user bot to run as a service bearing myservice@example.com as its JID. To Openfire, the user bot is just like other (human) users.</description>
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.igniterealtime.openfire</groupId>
             <artifactId>xmppserver</artifactId>
-            <version>4.8.1</version>
+            <version>4.8.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>4.2.1</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.igniterealtime.openfire.botz</groupId>
     <artifactId>botz</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
 
     <name>Botz</name>
     <description>The Botz library adds to the already rich and extensible Openfire with the ability to create internal user bots. With the Botz library, programmers may choose to develop a user bot to run as a service bearing myservice@example.com as its JID. To Openfire, the user bot is just like other (human) users.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.igniterealtime.openfire.botz</groupId>
     <artifactId>botz</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
 
     <name>Botz</name>
     <description>The Botz library adds to the already rich and extensible Openfire with the ability to create internal user bots. With the Botz library, programmers may choose to develop a user bot to run as a service bearing myservice@example.com as its JID. To Openfire, the user bot is just like other (human) users.</description>
@@ -181,7 +181,7 @@
         <dependency>
             <groupId>org.igniterealtime.openfire</groupId>
             <artifactId>xmppserver</artifactId>
-            <version>4.7.4</version>
+            <version>4.8.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <organization>

--- a/src/main/java/org/igniterealtime/openfire/botz/BotzConnection.java
+++ b/src/main/java/org/igniterealtime/openfire/botz/BotzConnection.java
@@ -179,13 +179,13 @@ public class BotzConnection extends VirtualConnection {
 
     @Override
     public Optional<String> getTLSProtocolName() {
-        return Optional.empty();
+        return this.session != null ? Optional.of(this.session.getTLSProtocolName())
+            : Optional.of("unknown");
     }
 
     @Override
     public Optional<String> getCipherSuiteName() {
-        return this.session  != null && this.session .getCipherSuiteName() != null
-            ? Optional.of(this.session.getCipherSuiteName())
+        return this.session != null ? Optional.of(this.session.getCipherSuiteName())
             : Optional.of("unknown");
     }
 


### PR DESCRIPTION
Fixes igniterealtime/Botz#10
Remove LocalClientSession from BotzConnection, see igniterealtime/Openfire#2303 Move duplicate session management to new abstract Connection…
Implemented abstract method Connection.getTLSProtocolName() and Connection.getCipherSuiteName()
Updated login, see Issue 10, Failing to build with Openfire-4.8.x 
Bump version to 1.2.2-snapshot